### PR TITLE
Fixes for composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
     "name": "arhitector/yandex",
     "description": "PHP SDK for Yandex disk. SDK для Яндекс диска.",
-	"license": "MIT",
-	"keywords": [
+    "license": "MIT",
+    "keywords": [
         "php", "curl", "yandex", "api", "client", "sdk", "disk",
         "yandex disk", "яндекс диск", "диск", "rest", "restful", "яндекс"
     ],
-	"authors": [
+    "authors": [
         {
             "name": "Dmitry Arhitector",
             "email": "lovesosabitch@yandex.ru"
@@ -16,10 +16,10 @@
         "php": ">=5.5",
         "php-curl-class/php-curl-class": "^3.4"
     },
-	"autoload": {
+    "autoload": {
         "psr-4": {
-            "Mackey\\Yandex\\": "yandex",
-            "Mackey\\DataContainer\\": "datacontainer"
+            "Mackey\\Yandex\\": "Yandex",
+            "Mackey\\DataContainer\\": "DataContainer"
         }
     }
 }


### PR DESCRIPTION
При работе с библиотекой обнаружил, что пути к неймспейсу в composer.json указаны без поддержки кросс платформенности - например на линукс системе пути регистрозависимы, а в composer.json пути прописаны в нижнем регистре и из-за этого не находит классы.

Так же добавил composer.lock и vendor в .gitignore.
